### PR TITLE
Changing order of include files to avoid duplication of Rtypes content

### DIFF
--- a/TPCCAGPUTracking/GlobalTracker/AliHLTTPCCAGPUTrackerBase.h
+++ b/TPCCAGPUTracking/GlobalTracker/AliHLTTPCCAGPUTrackerBase.h
@@ -19,10 +19,10 @@
 
 #define HLTCA_GPU_DEFAULT_MAX_SLICE_COUNT 36
 
+#include "AliHLTLogging.h"
 #include "AliHLTTPCCAGPUTracker.h"
 #include "AliHLTTPCCADef.h"
 #include "AliHLTTPCCATracker.h"
-#include "AliHLTLogging.h"
 #include "AliHLTTPCCASliceOutput.h"
 
 #ifdef __CINT__

--- a/TPCCAGPUTracking/Interface/AliHLTTPCCAO2Interface.cxx
+++ b/TPCCAGPUTracking/Interface/AliHLTTPCCAO2Interface.cxx
@@ -16,8 +16,8 @@
 //                                                                          *
 //***************************************************************************
 
-#include "AliHLTTPCCAO2Interface.h"
 #include "AliHLTTPCCAStandaloneFramework.h"
+#include "AliHLTTPCCAO2Interface.h"
 #include "standaloneSettings.h"
 #include <iostream>
 #include <fstream>

--- a/TPCCAGPUTracking/LinkDef_O2.h
+++ b/TPCCAGPUTracking/LinkDef_O2.h
@@ -5,5 +5,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class AliHLTTPCCAO2Interface+;
-
+#pragma link C++ class AliHLTTPCCATrackerFramework+;
+#pragma link C++ class AliHLTTPCCAGPUTrackerBase+;
 #endif

--- a/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAStandaloneFramework.h
+++ b/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAStandaloneFramework.h
@@ -9,10 +9,10 @@
 #ifndef ALIHLTTPCCASTANDALONEFRAMEWORK_H
 #define ALIHLTTPCCASTANDALONEFRAMEWORK_H
 
+#include "AliHLTTPCCATrackerFramework.h"
 #include "AliHLTTPCCADef.h"
 #include "AliHLTTPCGMMerger.h"
 #include "AliHLTTPCCAClusterData.h"
-#include "AliHLTTPCCATrackerFramework.h"
 #include "AliHLTTPCClusterMCData.h"
 #include "AliHLTTPCCAMCInfo.h"
 #include <iostream>

--- a/TPCCAGPUTracking/SliceTracker/AliHLTTPCCATrackerFramework.h
+++ b/TPCCAGPUTracking/SliceTracker/AliHLTTPCCATrackerFramework.h
@@ -10,11 +10,11 @@
 #ifndef ALIHLTTPCCATRACKERFRAMEWORK_H
 #define ALIHLTTPCCATRACKERFRAMEWORK_H
 
+#include "AliHLTLogging.h"
 #include "AliHLTTPCCATracker.h"
 #include "AliHLTTPCCAGPUTracker.h"
 #include "AliHLTTPCCAParam.h"
 #include "AliHLTTPCCASliceOutput.h"
-#include "AliHLTLogging.h"
 #include <iostream>
 #include <string.h>
 

--- a/TPCCAGPUTracking/Standalone/qa/qa.cpp
+++ b/TPCCAGPUTracking/Standalone/qa/qa.cpp
@@ -1,6 +1,5 @@
 #include "Rtypes.h"
 
-#include "AliHLTTPCCADef.h"
 #include "AliHLTTPCCASliceData.h"
 #include "AliHLTTPCCAStandaloneFramework.h"
 #include "AliHLTTPCCATrack.h"
@@ -8,6 +7,7 @@
 #include "AliHLTTPCCATrackerFramework.h"
 #include "AliHLTTPCGMMergedTrack.h"
 #include "AliHLTTPCGMPropagator.h"
+#include "AliHLTTPCCADef.h"
 #include "include.h"
 #include <algorithm>
 #include <cstdio>


### PR DESCRIPTION
AliTPCCommon package comes with its own copy of the Rtypes.h include
file from ROOT. In order to get the include protection to work, AliHLTLogging.h
needs to be included first because it picks up the original file from ROOT.

Similar for AliHLTTPCCADef.h which defines ClassDef macro again.

This is needed to fix the compilation of O2 with AliRoot.