### PR TITLE
Remove deprecated `register` keyword

### DIFF
--- a/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAHitArea.h
+++ b/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAHitArea.h
@@ -33,7 +33,7 @@ class AliHLTTPCCAHitArea
      * look up the next hit in the requested area.
      * Sets h to the coordinates and returns the index for the hit data
      */
-    MEM_TEMPLATE() GPUd() int GetNext( register GPUconstant() const MEM_CONSTANT(AliHLTTPCCATracker) &tracker, const MEM_TYPE( AliHLTTPCCARow) &row,
+    MEM_TEMPLATE() GPUd() int GetNext(GPUconstant() const MEM_CONSTANT(AliHLTTPCCATracker) &tracker, const MEM_TYPE( AliHLTTPCCARow) &row,
                  GPUglobalref() const MEM_GLOBAL(AliHLTTPCCASliceData) &slice, AliHLTTPCCAHit *h );
 
     float Y() const { return fY; }

--- a/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAMath.h
+++ b/TPCCAGPUTracking/SliceTracker/AliHLTTPCCAMath.h
@@ -45,14 +45,14 @@ class AliHLTTPCCAMath
     GPUd() static bool Finite( float x );
 
     GPUhd() static float Log(float x);
-    GPUd()  static int AtomicExch( register GPUglobalref() int *addr, int val );
-    GPUd()  static int AtomicAdd (register GPUglobalref() int *addr, int val );
-    GPUd()  static int AtomicMax (register GPUglobalref() int *addr, int val );
-    GPUd()  static int AtomicMin (register GPUglobalref() int *addr, int val );
-    GPUd()  static int AtomicExchShared(register GPUsharedref() int *addr, int val );
-    GPUd()  static int AtomicAddShared (register GPUsharedref() int *addr, int val );
-    GPUd()  static int AtomicMaxShared (register GPUsharedref() int *addr, int val );
-    GPUd()  static int AtomicMinShared (register GPUsharedref() int *addr, int val );
+    GPUd()  static int AtomicExch( GPUglobalref() int *addr, int val );
+    GPUd()  static int AtomicAdd ( GPUglobalref() int *addr, int val );
+    GPUd()  static int AtomicMax ( GPUglobalref() int *addr, int val );
+    GPUd()  static int AtomicMin ( GPUglobalref() int *addr, int val );
+    GPUd()  static int AtomicExchShared( GPUsharedref() int *addr, int val );
+    GPUd()  static int AtomicAddShared ( GPUsharedref() int *addr, int val );
+    GPUd()  static int AtomicMaxShared ( GPUsharedref() int *addr, int val );
+    GPUd()  static int AtomicMinShared ( GPUsharedref() int *addr, int val );
     GPUd()  static int Mul24( int a, int b );
     GPUd()  static float FMulRZ( float a, float b );
 };
@@ -182,10 +182,10 @@ GPUhd() inline float AliHLTTPCCAMath::Log(float x)
 }
 
 #if defined(__OPENCL__)
-GPUd()  inline int AliHLTTPCCAMath::AtomicExchShared(register GPUsharedref() int *addr, int val ) {return ::atomic_xchg( (volatile __local int*) addr, val );}
-GPUd()  inline int AliHLTTPCCAMath::AtomicAddShared (register GPUsharedref() int *addr, int val ) {return ::atomic_add( (volatile __local int*) addr, val );}
-GPUd()  inline int AliHLTTPCCAMath::AtomicMaxShared (register GPUsharedref() int *addr, int val ) {return ::atomic_max( (volatile __local int*) addr, val );}
-GPUd()  inline int AliHLTTPCCAMath::AtomicMinShared (register GPUsharedref() int *addr, int val ) {return ::atomic_min( (volatile __local int*) addr, val );}
+GPUd()  inline int AliHLTTPCCAMath::AtomicExchShared( GPUsharedref() int *addr, int val ) {return ::atomic_xchg( (volatile __local int*) addr, val );}
+GPUd()  inline int AliHLTTPCCAMath::AtomicAddShared ( GPUsharedref() int *addr, int val ) {return ::atomic_add( (volatile __local int*) addr, val );}
+GPUd()  inline int AliHLTTPCCAMath::AtomicMaxShared ( GPUsharedref() int *addr, int val ) {return ::atomic_max( (volatile __local int*) addr, val );}
+GPUd()  inline int AliHLTTPCCAMath::AtomicMinShared ( GPUsharedref() int *addr, int val ) {return ::atomic_min( (volatile __local int*) addr, val );}
 #else
 GPUd()  inline int AliHLTTPCCAMath::AtomicExchShared( int *addr, int val ) {return(AliHLTTPCCAMath::AtomicExch(addr, val));}
 GPUd()  inline int AliHLTTPCCAMath::AtomicAddShared ( int *addr, int val ) {return(AliHLTTPCCAMath::AtomicAdd(addr, val));}
@@ -193,7 +193,7 @@ GPUd()  inline int AliHLTTPCCAMath::AtomicMaxShared ( int *addr, int val ) {retu
 GPUd()  inline int AliHLTTPCCAMath::AtomicMinShared ( int *addr, int val ) {return(AliHLTTPCCAMath::AtomicMin(addr, val));}
 #endif
 
-GPUd()  inline int AliHLTTPCCAMath::AtomicExch(register GPUglobalref() int *addr, int val )
+GPUd()  inline int AliHLTTPCCAMath::AtomicExch( GPUglobalref() int *addr, int val )
 {
 #if defined(HLTCA_GPUCODE) && defined(__OPENCL__)
 	return ::atomic_xchg( (volatile __global int*) addr, val );
@@ -206,7 +206,7 @@ GPUd()  inline int AliHLTTPCCAMath::AtomicExch(register GPUglobalref() int *addr
 #endif //HLTCA_GPUCODE
 }
 
-GPUd()  inline int AliHLTTPCCAMath::AtomicAdd (register GPUglobalref() int *addr, int val )
+GPUd()  inline int AliHLTTPCCAMath::AtomicAdd ( GPUglobalref() int *addr, int val )
 {
 #if defined(HLTCA_GPUCODE) && defined(__OPENCL__)
   return ::atomic_add( (volatile __global int*) addr, val );
@@ -219,7 +219,7 @@ GPUd()  inline int AliHLTTPCCAMath::AtomicAdd (register GPUglobalref() int *addr
 #endif //HLTCA_GPUCODE
 }
 
-GPUd()  inline int AliHLTTPCCAMath::AtomicMax (register GPUglobalref() int *addr, int val )
+GPUd()  inline int AliHLTTPCCAMath::AtomicMax ( GPUglobalref() int *addr, int val )
 {
 #if defined(HLTCA_GPUCODE) && defined(__OPENCL__)
   return ::atomic_max( (volatile __global int*) addr, val );
@@ -232,7 +232,7 @@ GPUd()  inline int AliHLTTPCCAMath::AtomicMax (register GPUglobalref() int *addr
 #endif //HLTCA_GPUCODE
 }
 
-GPUd()  inline int AliHLTTPCCAMath::AtomicMin (register GPUglobalref() int *addr, int val )
+GPUd()  inline int AliHLTTPCCAMath::AtomicMin ( GPUglobalref() int *addr, int val )
 {
 #if defined(HLTCA_GPUCODE) && defined(__OPENCL__)
   return ::atomic_min( (volatile __global int*) addr, val );

--- a/TPCCAGPUTracking/SliceTracker/AliHLTTPCCATrackletConstructor.h
+++ b/TPCCAGPUTracking/SliceTracker/AliHLTTPCCATrackletConstructor.h
@@ -81,7 +81,7 @@ public:
 #endif //HLTCA_GPU_TRACKLET_CONSTRUCTOR_DO_PROFILE
 	};
 
-	MEM_CLASS_PRE2() GPUd() static void InitTracklet( register MEM_LG2(AliHLTTPCCATrackParam) &tParam );
+	MEM_CLASS_PRE2() GPUd() static void InitTracklet( MEM_LG2(AliHLTTPCCATrackParam) &tParam );
 
 	MEM_CLASS_PRE2() GPUd() static void UpdateTracklet
 		( int nBlocks, int nThreads, int iBlock, int iThread,
@@ -91,7 +91,7 @@ public:
 		( int nBlocks, int nThreads, int iBlock, int iThread,
 		  MEM_LOCAL(GPUsharedref() AliHLTTPCCASharedMemory) &s, AliHLTTPCCAThreadMemory &r, GPUconstant() MEM_LG2(AliHLTTPCCATracker) &tracker, MEM_LG3(AliHLTTPCCATrackParam) &tParam );
 
-	MEM_CLASS_PRE2() GPUd() static bool CheckCov(register MEM_LG2(AliHLTTPCCATrackParam) &tParam);
+	MEM_CLASS_PRE2() GPUd() static bool CheckCov( MEM_LG2(AliHLTTPCCATrackParam) &tParam );
 
 	GPUd() static void DoTracklet(GPUconstant() MEM_CONSTANT(AliHLTTPCCATracker)& tracker, GPUsharedref() AliHLTTPCCATrackletConstructor::MEM_LOCAL(AliHLTTPCCASharedMemory)& sMem, AliHLTTPCCAThreadMemory& rMem);
 


### PR DESCRIPTION
* Fix O2 build errors on macOS (where deprecation warnings become errors because
  of forced `-Werror` in C.I.)
* Allow using C++17 (where `register` no longer exists), see alisw/alidist#1293