### PR TITLE
Add VertexerTraits in AliGPUReconstruction

### DIFF
--- a/TPCCAGPUTracking/GlobalTracker/AliGPUReconstruction.cxx
+++ b/TPCCAGPUTracking/GlobalTracker/AliGPUReconstruction.cxx
@@ -45,9 +45,10 @@
 
 #ifdef HAVE_O2HEADERS
 #include "ITStracking/TrackerTraitsCPU.h"
+#include "ITStracking/VertexerTraits.h"
 #include "TRDBase/TRDGeometryFlat.h"
 #else
-namespace o2 { namespace ITS { class TrackerTraits {}; class TrackerTraitsCPU : public TrackerTraits {}; }}
+namespace o2 { namespace ITS { class TrackerTraits {}; class TrackerTraitsCPU : public TrackerTraits {}; class VertexerTraits }}
 namespace o2 { namespace trd { struct TRDGeometryFlat {}; }}
 #endif
 using namespace o2::ITS;
@@ -71,6 +72,7 @@ AliGPUReconstruction::AliGPUReconstruction(const AliGPUCASettingsProcessing& cfg
 	if (mProcessingSettings.deviceType == CPU)
 	{
 		mITSTrackerTraits.reset(new o2::ITS::TrackerTraitsCPU);
+		mITSVertexerTraits.reset(new o2::ITS::VertexerTraits);
 	}
 	memset(mSliceOutput, 0, sizeof(mSliceOutput));
 }
@@ -80,6 +82,7 @@ AliGPUReconstruction::~AliGPUReconstruction()
 	//Reset these explicitly before the destruction of other members unloads the library
 	mTRDTracker.reset();
 	mITSTrackerTraits.reset();
+	mITSVertexerTraits.reset();
 }
 
 int AliGPUReconstruction::Init()

--- a/TPCCAGPUTracking/GlobalTracker/AliGPUReconstruction.h
+++ b/TPCCAGPUTracking/GlobalTracker/AliGPUReconstruction.h
@@ -15,6 +15,7 @@
 #include "AliHLTTPCCASliceOutput.h"
 #include "AliHLTTPCCATracker.h"
 #include "AliHLTTPCGMMerger.h"
+
 class AliHLTTPCCASliceOutput;
 class AliHLTTPCCASliceOutTrack;
 class AliHLTTPCCASliceOutCluster;
@@ -31,7 +32,7 @@ struct AliHLTTRDTrackletLabels;
 class AliGPUCADisplay;
 class AliGPUCAQA;
 
-namespace o2 { namespace ITS { class TrackerTraits; }}
+namespace o2 { namespace ITS { class TrackerTraits; class VertexerTraits; }}
 namespace o2 { namespace trd { class TRDGeometryFlat; }}
 namespace o2 { namespace TPC { struct ClusterNativeAccessFullTPC; struct ClusterNative; }}
 namespace ali_tpc_common { namespace tpc_fast_transformation { class TPCFastTransform; }}
@@ -188,7 +189,8 @@ public:
 	//Getters for external usage of tracker classes
 	AliHLTTRDTracker* GetTRDTracker() {return mTRDTracker.get();}
 	o2::ITS::TrackerTraits* GetITSTrackerTraits() {return mITSTrackerTraits.get();}
-	AliHLTTPCCATracker* GetTPCSliceTrackers() {return mTPCSliceTrackersCPU;}
+    o2::ITS::VertexerTraits* GetITSVertexerTraits() {return mITSVertexerTraits.get();}
+ 	AliHLTTPCCATracker* GetTPCSliceTrackers() {return mTPCSliceTrackersCPU;}
 	const AliHLTTPCCATracker* GetTPCSliceTrackers() const {return mTPCSliceTrackersCPU;}
 	const AliHLTTPCGMMerger& GetTPCMerger() const {return mTPCMergerCPU;}
 	AliHLTTPCGMMerger& GetTPCMerger() {return mTPCMergerCPU;}
@@ -246,6 +248,7 @@ protected:
 	//Pointers to tracker classes
 	std::unique_ptr<AliHLTTRDTracker> mTRDTracker;
 	std::unique_ptr<o2::ITS::TrackerTraits> mITSTrackerTraits;
+	std::unique_ptr<o2::ITS::VertexerTraits> mITSVertexerTraits;
 	AliHLTTPCCATracker mTPCSliceTrackersCPU[NSLICES];
 	AliHLTTPCGMMerger mTPCMergerCPU;
 	AliHLTTPCCASliceOutput* mSliceOutput[NSLICES];


### PR DESCRIPTION
This PR will add the possibility to get the VertexerTraits from the `AliGPUReconstruction` interface.